### PR TITLE
Avoid `@Redirect` conflict by using `@ModifyExpressionValue`

### DIFF
--- a/src/main/java/com/github/hhhzzzsss/songplayer/mixin/ClientPlayerEntityMixin.java
+++ b/src/main/java/com/github/hhhzzzsss/songplayer/mixin/ClientPlayerEntityMixin.java
@@ -1,21 +1,20 @@
 package com.github.hhhzzzsss.songplayer.mixin;
 
 import com.github.hhhzzzsss.songplayer.playing.SongHandler;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import net.minecraft.client.network.ClientPlayerEntity;
-import net.minecraft.entity.player.PlayerAbilities;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ClientPlayerEntity.class)
 public class ClientPlayerEntityMixin {
-    @Redirect(method = "tickMovement()V", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/PlayerAbilities;allowFlying:Z", opcode = Opcodes.GETFIELD))
-    private boolean getAllowFlying(PlayerAbilities playerAbilities) {
+    @ModifyExpressionValue(method = "tickMovement()V", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/PlayerAbilities;allowFlying:Z", opcode = Opcodes.GETFIELD))
+    private boolean getAllowFlying(boolean allowFlying) {
         if (!SongHandler.getInstance().isIdle()) {
             return true;
         } else {
-            return playerAbilities.allowFlying;
+            return allowFlying;
         }
     }
 }


### PR DESCRIPTION
Both Baritone and SongPlayer redirect the same field access, making mixin crash the game if both are installed simultaneously.
Unlike `@Redirect`, `@ModifyExpressionValue` allows multiple mixins targeting the same operation by passing the result of the previous handler to the next handler. This also works with at most one `@Redirect` as the innermost handler, so changing this here without changing it in Baritone is enough to prevent the crash.

Fixes https://github.com/hhhzzzsss/SongPlayer/issues/68
Fixes https://github.com/cabaletta/baritone/issues/4666